### PR TITLE
Shortened Radio 3S name + Changed region to Global

### DIFF
--- a/assets/data/stations.json
+++ b/assets/data/stations.json
@@ -686,9 +686,9 @@
   "radio3s": {
     "displayorder": 85,
     "genres": ["electro", "world", "beat"],
-    "language": "en-US",
+    "language": "en",
     "logosource": "//radio3s.org/Radio-Solar-Sound-System.png",
-    "name": "Radio 3S / SolarSoundSystem",
+    "name": "Radio 3S",
     "streams": [
       {
         "mimetype": "audio/mpeg",


### PR DESCRIPTION
Creating radios with too long names are resulting in the bug of the play icon